### PR TITLE
Sort files used for hash building to make hash system-independent

### DIFF
--- a/src/Asset/HashBuilder.php
+++ b/src/Asset/HashBuilder.php
@@ -118,7 +118,7 @@ final class HashBuilder
         $finder = null;
         foreach ($patterns as $pattern) {
             try {
-                $pathfinder = FileFinder::create()->ignoreUnreadableDirs(true)->ignoreVCS(true);
+                $pathfinder = FileFinder::create()->ignoreUnreadableDirs(true)->ignoreVCS(true)->sortByName();
                 $hasFile = preg_match(self::PATTERN_REGEX, $pattern, $matches);
                 $dir = "{$basePath}/" . ltrim($hasFile ? $matches[1] : $pattern, './');
                 $hasFile


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix.


**What is the current behavior?** (You can also link to an open issue here)
Symfony file findes uses `RecursiveDirectoryIterator` under the hood. It has not to default file order. It's important because different files order causes different calculated hash - https://github.com/inpsyde/composer-asset-compiler/blob/878fee76f16ee02b89c1fa1de5951eaeefc594df/src/Asset/HashBuilder.php#L86-L94


**What is the new behavior (if this is a feature change)?**
The suggested fix is to stick file order with the file name (order doesn't matter in fact). This way locally or on every CI system hash will be the same.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
