### PR TITLE
Improve `src-path` documentation

### DIFF
--- a/docs/007-Hash_and_Lock.md
+++ b/docs/007-Hash_and_Lock.md
@@ -25,8 +25,8 @@ That's why there's a `src-paths` configuration, that can be used to instruct _Co
     "composer-asset-compiler": {
       "script": "build",
       "src-paths": [
-        "./js/*/*.js",
-        "./sass/*/*.scss"
+        "./js/*.js",
+        "./sass/*.scss"
       ]
     }
   }

--- a/tests/functional/HashBuildingTest.php
+++ b/tests/functional/HashBuildingTest.php
@@ -36,6 +36,7 @@ class HashBuildingTest extends FunctionalTestCase
         static::assertTrue($this->io->hasOutputThatMatches('~two/a\.css~'));
         static::assertTrue($this->io->hasOutputThatMatches('~two/three/b\.js~'));
         static::assertTrue($this->io->hasOutputThatMatches('~some-file\.js~'));
+        static::assertTrue($this->io->hasOutputThatMatches('~c\.css~'));
         static::assertSame([], $this->io->errors);
     }
 }

--- a/tests/resources/05/repo/composer.json
+++ b/tests/resources/05/repo/composer.json
@@ -13,7 +13,7 @@
       },
       "script": "build",
       "src-paths": [
-        "src/*/*.css",
+        "src/*.css",
         "./src/*/*.js",
         "lib/"
       ],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement.


**What is the current behavior?** (You can also link to an open issue here)
The current documentation is a bit misleading. We have standard directories like the following:
```
/resources
   /scss
      /index.scss
  /js
     /index.js
```

When you use `"./js/*/*.js",  "./scss/*/*.scss"` you miss files that are placed directly under `js` and `scss` directories.
So I think the most beneficial case is to not include the subdirectory pattern `/*/`.

**What is the new behavior (if this is a feature change)?**
I slightly changed that part of the documentation and added the correspond assert (if someone uses tests as documentation).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
