### PR TITLE
Allow wildcard in file name

### DIFF
--- a/src/Asset/HashBuilder.php
+++ b/src/Asset/HashBuilder.php
@@ -18,7 +18,7 @@ use Symfony\Component\Finder\Finder as FileFinder;
 
 final class HashBuilder
 {
-    private const PATTERN_REGEX = '~^(.+?)/([^/]+\.(?:[a-z0-9]{1,4}(?:\.[a-z0-9]{1,4})?|\*))$~i';
+    private const PATTERN_REGEX = '~^(.+?)/([^/]+)$~';
     /**
      * @var array<string, string>
      */

--- a/tests/functional/HashBuildingTest.php
+++ b/tests/functional/HashBuildingTest.php
@@ -35,6 +35,7 @@ class HashBuildingTest extends FunctionalTestCase
         static::assertSame(40, strlen($hash));
         static::assertTrue($this->io->hasOutputThatMatches('~two/a\.css~'));
         static::assertTrue($this->io->hasOutputThatMatches('~two/three/b\.js~'));
+        static::assertTrue($this->io->hasOutputThatMatches('~two/three/b1\.jsx~'));
         static::assertTrue($this->io->hasOutputThatMatches('~some-file\.js~'));
         static::assertSame([], $this->io->errors);
     }

--- a/tests/resources/05/repo/composer.json
+++ b/tests/resources/05/repo/composer.json
@@ -13,8 +13,8 @@
       },
       "script": "build",
       "src-paths": [
-        "src/*/*.css",
-        "./src/*/*.js",
+        "src/*/*",
+        "./src/*/*.js*",
         "lib/"
       ],
       "pre-compiled": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
The current file detection Regexp is very strict and doesn't allow using of wildcards as part of the filename while the Symfony Finder component allows it - https://symfony.com/doc/current/components/finder.html#file-name (and even Regexp).


**What is the new behavior (if this is a feature change)?**
I'm not sure we really need to validate file extensions for our purposes. So the simplified Regexp allows using anything as the file name. It brings benefits for `*.js*` matching both `js` and `jsx` files for instance. 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
