### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/016-Environment_Variables.md
+++ b/docs/016-Environment_Variables.md
@@ -21,8 +21,8 @@ nav_order: 17
 | `GITHUB_API_USER`                           | Alternative to `GITHUB_USER_NAME`.                                                                                                           |
 | `GITHUB_ACTOR`                              | Alternative to `GITHUB_USER_NAME`.                                                                                                           |
 | `GITHUB_USER_TOKEN`                         | Set the GitHub Personal Access Token to be used for GitHub pre-compilation adapters.                                                         |
-| `GITHUB_API_TOKEN`                          | Alternative to `GITHUB_API_TOKEN`.                                                                                                           |
-| `GITHUB_TOKEN`                              | Alternative to `GITHUB_API_TOKEN`.                                                                                                           |
+| `GITHUB_API_TOKEN`                          | Alternative to `GITHUB_USER_TOKEN`.                                                                                                           |
+| `GITHUB_TOKEN`                              | Alternative to `GITHUB_USER_TOKEN`.                                                                                                           |
 | `GITHUB_API_REPOSITORY`                     | Set the GitHub repository to be used for GitHub pre-compilation adapters. Alternative to `pre-compiled.config.repository` setting.           |
 | `GITHUB_REPOSITORY`                         | Alternative to `GITHUB_API_REPOSITORY`.                                                                                                      |
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Typo in "Alternative to `GITHUB_API_TOKEN`.". `GITHUB_API_TOKEN` and `GITHUB_TOKEN` are alternatives to `GITHUB_USER_TOKEN`.


**What is the new behavior (if this is a feature change)?**
Fixed typos.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
