### PR TITLE
docs: Make `--ignore-lock` documentation align with implementation

### DIFF
--- a/docs/007-Hash_and_Lock.md
+++ b/docs/007-Hash_and_Lock.md
@@ -56,7 +56,7 @@ Please note _Composer Asset Compiler_ uses [Symfony Finder](https://symfony.com/
 When compiling assets via the `compile-assets` command, it is possible to pass a `--ignore-lock` flag to always build assets, regardless the presence and the content of the lock file.
 
 ````shell
-composer compile-assets --ignore-lock
+composer compile-assets --ignore-lock=*
 ````
 
 

--- a/docs/015-CLI-Parameters.md
+++ b/docs/015-CLI-Parameters.md
@@ -8,11 +8,11 @@ nav_order: 16
 
 ## Command: `compile-assets`
 
-| Parameter                    | Description                                                                                                                                                   |
-|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--ignore-lock[=<packages>]` | Ignores locks for all or specific packages. Multiple packets must be comma-separated.                                                                         |
-| `--mode=<mode>`              | Specifies the "execution mode" which is used to select between multiple configuration variants.                                                               |
-| `--no-dev`                   | Simulate auto-run on Composer installation/update with the `--no-dev` flag.<br />This causes the plugin to check for `$default-no-dev` as the default "mode". |
+| Parameter                  | Description                                                                                                                                                   |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--ignore-lock=<packages>` | Ignores locks of packages specified as a comma-separated list. If a wildcard is passed instead (`*`), ALL locks are ignored.                                  |
+| `--mode=<mode>`            | Specifies the "execution mode" which is used to select between multiple configuration variants.                                                               |
+| `--no-dev`                 | Simulate auto-run on Composer installation/update with the `--no-dev` flag.<br />This causes the plugin to check for `$default-no-dev` as the default "mode". |
 
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update

**What is the current behavior?** (You can also link to an open issue here)
You could get the im,pression that passing `--ignore-lock` **without parameters** would result in all lockfiles being ignored.
However, the actual implementation actually checks for an asterisk (instead of comma-separated package names)


**What is the new behavior (if this is a feature change)?**
The documentation is updated to accurately reflect the implementation


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
