### PR TITLE
3.x disk space usage alternative

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "scripts": {
         "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-        "cs:fix": "@php ./vendor/bin/phpcbf",
+        "cs:fix": "@php ./vendor/bin/phpcbf --runtime-set testVersion 7.2",
         "psalm": "@php ./vendor/vimeo/psalm/psalm --no-cache --output-format=compact --find-unused-psalm-suppress",
         "tests": "@php ./vendor/phpunit/phpunit/phpunit",
         "qa": [

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     },
     "scripts": {
         "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+        "cs:fix": "@php ./vendor/bin/phpcbf",
         "psalm": "@php ./vendor/vimeo/psalm/psalm --no-cache --output-format=compact --find-unused-psalm-suppress",
         "tests": "@php ./vendor/phpunit/phpunit/phpunit",
         "qa": [

--- a/src/Asset/Processor.php
+++ b/src/Asset/Processor.php
@@ -13,12 +13,17 @@ namespace Inpsyde\AssetsCompiler\Asset;
 
 use Composer\Util\Filesystem;
 use Composer\Util\ProcessExecutor;
+use Inpsyde\AssetsCompiler\Composer\Command\CompileAssetsPassedArguments;
 use Inpsyde\AssetsCompiler\PackageManager\PackageManager;
 use Inpsyde\AssetsCompiler\PackageManager\Finder;
 use Inpsyde\AssetsCompiler\PreCompilation;
+use Inpsyde\AssetsCompiler\PreCompilation\Handler;
+use Inpsyde\AssetsCompiler\Process\ParallelProcessManager;
+use Inpsyde\AssetsCompiler\Process\ProcessGroup;
 use Inpsyde\AssetsCompiler\Process\Results;
 use Inpsyde\AssetsCompiler\Process\ParallelManager;
 use Inpsyde\AssetsCompiler\Util\Io;
+use Symfony\Component\Process\Process;
 
 /*
  * phpcs:disable Inpsyde.CodeQuality.PropertyPerClassLimit
@@ -51,7 +56,7 @@ class Processor
     private $locker;
 
     /**
-     * @var ParallelManager
+     * @var ParallelProcessManager
      */
     private $parallelManager;
 
@@ -81,15 +86,21 @@ class Processor
     private $tempDir = [false, null];
 
     /**
+     * @var CompileAssetsPassedArguments
+     */
+    private $passedArguments;
+
+    /**
      * @param Io $io
      * @param Config $config
      * @param Finder $packageManagerFinder
      * @param ProcessExecutor $executor
-     * @param ParallelManager $parallelManager
+     * @param ParallelProcessManager $parallelManager
      * @param Locker $locker
-     * @param PreCompilation\Handler $preCompiler
+     * @param Handler $preCompiler
      * @param callable $outputHandler
      * @param Filesystem $filesystem
+     * @param CompileAssetsPassedArguments $arguments
      * @return Processor
      */
     public static function new(
@@ -97,11 +108,12 @@ class Processor
         Config $config,
         Finder $packageManagerFinder,
         ProcessExecutor $executor,
-        ParallelManager $parallelManager,
+        ParallelProcessManager $parallelManager,
         Locker $locker,
         PreCompilation\Handler $preCompiler,
         callable $outputHandler,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        CompileAssetsPassedArguments $arguments
     ): Processor {
 
         return new self(
@@ -113,7 +125,8 @@ class Processor
             $locker,
             $preCompiler,
             $outputHandler,
-            $filesystem
+            $filesystem,
+            $arguments
         );
     }
 
@@ -133,11 +146,12 @@ class Processor
         Config $config,
         Finder $packageManagerFinder,
         ProcessExecutor $executor,
-        ParallelManager $parallelManager,
+        ParallelProcessManager $parallelManager,
         Locker $locker,
         PreCompilation\Handler $preCompiler,
         callable $outputHandler,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        CompileAssetsPassedArguments $arguments
     ) {
 
         $this->io = $io;
@@ -149,12 +163,14 @@ class Processor
         $this->preCompiler = $preCompiler;
         $this->outputHandler = $outputHandler;
         $this->filesystem = $filesystem;
+        $this->passedArguments = $arguments;
     }
 
     /**
      * @param \Iterator $assets
      * @return bool
      */
+    // phpcs:ignore Inpsyde.CodeQuality.FunctionLength.TooLong, Generic.Metrics.CyclomaticComplexity.TooHigh
     public function process(\Iterator $assets): bool
     {
         $rootConfig = $this->config->rootConfig();
@@ -179,6 +195,10 @@ class Processor
                 continue;
             }
 
+            if ($this->passedArguments->forceDeleteNodeModules()) {
+                $shouldWipe = true;
+            }
+
             /** @var Asset $asset */
             if ($this->maybeSkipAsset($asset)) {
                 continue;
@@ -192,30 +212,153 @@ class Processor
                 return false;
             }
 
-            $installedDeps = $this->doDependencies($asset, $commands, $rootConfig);
+            $assetCommands = [];
 
-            if (!$installedDeps && $stopOnFailure) {
-                return false;
+            $installCommand = $this->buildDependenciesCommand($asset, $commands);
+
+            if (is_string($installCommand) && $installCommand) {
+                $assetCommands[] = [
+                    'path' => $asset->path(),
+                    'command' => $installCommand,
+                ];
             }
 
-            $return = $installedDeps && $return;
             $commandStrings = $this->buildScriptCommands($asset, $commands);
 
-            // No script, we can lock already
-            if (!$commandStrings) {
-                $this->locker->lock($asset);
-                $shouldWipe and $this->wipeNodeModules($path);
-
-                continue;
+            foreach ($commandStrings as $commandString) {
+                $assetCommands[] = [
+                    'path' => $asset->path(),
+                    'command' => $commandString,
+                ];
             }
 
-            $processManager = $processManager->pushAssetToProcess($asset, ...$commandStrings);
-            $shouldWipe and $toWipe[$name] = $shouldWipe;
+            if ($shouldWipe) {
+                $deleteNodeModulesCommand = $this->wipeNodeModulesCommand($path);
+                $assetCommands[] = [
+                    'path' => $rootConfig->path(),
+                    'command' => $deleteNodeModulesCommand,
+                ];
+            }
+
+            $parentProcessArgs = array_shift($assetCommands);
+            $childrenProcessesArgs = $assetCommands;
+
+            $parentProcess = $processManager->createProcess(
+                $parentProcessArgs['command'],
+                $parentProcessArgs['path']
+            );
+
+            $onGroupCompleted = function () use ($asset) {
+                $this->io->writeComment(sprintf('Locking asset %s', $asset->name()));
+                $this->locker->lock($asset);
+            };
+
+            $onParentErrored = static function (Process $parent) {
+                throw new \RuntimeException(
+                    "Parent process failed: " . $parent->getErrorOutput()
+                );
+            };
+
+            $onChildErrored = static function (Process $parent) {
+                throw new \RuntimeException(
+                    "Child process failed: " . $parent->getErrorOutput()
+                );
+            };
+
+            $onParentProcessStart = function (Process $process) {
+                $this->io->writeComment(
+                    sprintf(
+                        'Starting %s in %s',
+                        $process->getCommandLine(),
+                        $process->getWorkingDirectory()
+                    )
+                );
+            };
+
+            $onChildProcessStart = function (Process $process) {
+                $this->io->writeComment(
+                    sprintf(
+                        'Starting %s in %s',
+                        $process->getCommandLine(),
+                        $process->getWorkingDirectory()
+                    )
+                );
+            };
+
+            $processGroup = new ProcessGroup(
+                $parentProcess,
+                $onParentProcessStart,
+                $onChildProcessStart,
+                $onGroupCompleted,
+                $onParentErrored,
+                $onChildErrored
+            );
+            foreach ($childrenProcessesArgs as $childrenProcessArgs) {
+                $childProcess = $processManager->createProcess(
+                    $childrenProcessArgs['command'],
+                    $childrenProcessArgs['path']
+                );
+                $processGroup->addChild($childProcess);
+            }
+
+            $processManager->addGroup($processGroup);
         }
 
-        $results = $processManager->execute($this->io, $stopOnFailure);
+        /**
+         * @param ProcessGroup[] $groups
+         * @param int $batchNumber
+         * @param int $totalBatches
+         * @param int $groupsCount
+         * @return void
+         */
+        $onBatchStartCallback = function (
+            array $groups,
+            int $batchNumber,
+            int $totalBatches,
+            int $groupsCount
+        ): void {
+            $this->io->write(
+                sprintf(
+                    "Starting batch %d of %d with %d group(s)",
+                    $batchNumber,
+                    $totalBatches,
+                    $groupsCount
+                )
+            );
+        };
 
-        return $this->handleResults($results, $toWipe) && $return;
+        /**
+         * @param ProcessGroup[] $groups
+         * @param int $batchNumber
+         * @return void
+         */
+        $onBatchCompletedCallback = function (
+            array $groups,
+            int $batchNumber
+        ): void {
+            $this->io->write(sprintf("Batch %d completed", $batchNumber));
+            if ($this->passedArguments->clearPackageManagerCache()) {
+                $this->io->writeComment('Clearing package manager cache');
+                $result = $this->executor->execute(
+                    'npm cache clear --force',
+                    $this->outputHandler,
+                    $this->config->rootConfig()->path()
+                );
+                $this->io->writeComment(sprintf('Finish clearing cache with result: %d', $result));
+            }
+        };
+
+        $onAllBatchesCompletedCallback = function () {
+            $this->io->writeInfo('All batches completed');
+        };
+
+        $processManager->run(
+            $onBatchStartCallback,
+            $onBatchCompletedCallback,
+            $onAllBatchesCompletedCallback
+        );
+
+        return true;
     }
 
     /**
@@ -233,6 +376,15 @@ class Processor
         }
 
         return [$name, $path, $root->isWipeAllowedFor($path)];
+    }
+
+    /**
+     * @param string $packageFolder
+     * @return bool
+     */
+    public function isWipePossible(string $packageFolder): bool
+    {
+        return true;
     }
 
     /**
@@ -301,10 +453,48 @@ class Processor
     }
 
     /**
+     * Same as previous doDependencies but without
+     * executing the process and without handling isolated cache
+     *
+     * @param Asset $asset
+     * @param PackageManager $packageManager
+     * @return bool|string
+     */
+    // phpcs:ignore Inpsyde.CodeQuality.ReturnTypeDeclaration.NoReturnType
+    private function buildDependenciesCommand(
+        Asset $asset,
+        PackageManager $packageManager
+    ) {
+
+        $isUpdate = $asset->isUpdate();
+        $isInstall = $asset->isInstall();
+
+        if (!$isUpdate && !$isInstall) {
+            return true;
+        }
+
+        $cwd = $asset->path();
+        if (!$cwd || !is_dir($cwd)) {
+            return false;
+        }
+
+        $command = $isUpdate
+            ? $packageManager->updateCmd($this->io)
+            : $packageManager->installCmd($this->io);
+
+        if (!$command) {
+            return false;
+        }
+
+        return $command;
+    }
+
+    /**
      * @param Asset $asset
      * @param PackageManager $packageManager
      * @param RootConfig $rootConfig
      * @return bool
+     * @deprecated
      */
     private function doDependencies(
         Asset $asset,
@@ -408,23 +598,10 @@ class Processor
      * @param string $baseDir
      * @return bool|null
      */
-    private function wipeNodeModules(string $baseDir): ?bool
+    private function wipeNodeModulesCommand(string $baseDir): string
     {
         $dir = rtrim($this->filesystem->normalizePath($baseDir), '/') . "/node_modules";
-        if (!is_dir($dir)) {
-            $this->io->writeVerbose("  '{$dir}' not found, nothing to wipe.");
-
-            return null;
-        }
-
-        $this->io->writeVerboseComment("Wiping '{$dir}'...");
-
-        $doneWipe = $this->filesystem->removeDirectory($dir);
-        $doneWipe
-            ? $this->io->writeVerboseInfo('  success!')
-            : $this->io->writeVerboseError('  failed!');
-
-        return $doneWipe;
+        return sprintf('composer filesystem-delete-folder --path="%s"', $dir);
     }
 
     /**
@@ -459,10 +636,6 @@ class Processor
             $success = $successes->dequeue();
             [, $asset] = $success;
             $this->locker->lock($asset);
-            if (!empty($toWipe[$asset->name()])) {
-                $path = $asset->path();
-                $path and $this->wipeNodeModules($path);
-            }
         }
 
         return $results->isSuccessful();

--- a/src/Asset/Processor.php
+++ b/src/Asset/Processor.php
@@ -30,6 +30,7 @@ use Symfony\Component\Process\Process;
  */
 class Processor
 {
+    const MODE_DEPLOYMENT = 'deployment';
     /**
      * @var Io
      */
@@ -178,7 +179,9 @@ class Processor
             throw new \Error('Invalid root config.');
         }
 
-        $toWipe = [];
+        $globalWipeNodeModules = $this->isWipeNodeModulesEnabledGlobally();
+        $globalCleanPackageManagerCache = $this->isCleanPackageManagerCacheEnabledGlobally();
+
         $stopOnFailure = $rootConfig->stopOnFailure();
         $return = true;
         $processManager = $this->parallelManager;
@@ -195,7 +198,7 @@ class Processor
                 continue;
             }
 
-            if ($this->passedArguments->forceDeleteNodeModules()) {
+            if ($globalWipeNodeModules) {
                 $shouldWipe = true;
             }
 
@@ -335,9 +338,9 @@ class Processor
         $onBatchCompletedCallback = function (
             array $groups,
             int $batchNumber
-        ): void {
+        ) use ($globalCleanPackageManagerCache): void {
             $this->io->write(sprintf("Batch %d completed", $batchNumber));
-            if ($this->passedArguments->clearPackageManagerCache()) {
+            if ($globalCleanPackageManagerCache) {
                 $this->io->writeComment('Clearing package manager cache');
                 $result = $this->executor->execute(
                     'npm cache clear --force',
@@ -359,6 +362,18 @@ class Processor
         );
 
         return true;
+    }
+
+    private function isWipeNodeModulesEnabledGlobally(): bool
+    {
+        return $this->passedArguments->mode() === static::MODE_DEPLOYMENT
+            || $this->passedArguments->forceDeleteNodeModules();
+    }
+
+    private function isCleanPackageManagerCacheEnabledGlobally(): bool
+    {
+        return $this->passedArguments->mode() === static::MODE_DEPLOYMENT
+            || $this->passedArguments->clearPackageManagerCache();
     }
 
     /**

--- a/src/Asset/RootConfig.php
+++ b/src/Asset/RootConfig.php
@@ -230,6 +230,10 @@ final class RootConfig
      */
     public function isWipeAllowedFor(string $packageFolder): bool
     {
+        /**
+         * I will not recommend to do this check here, this function is whether resolving if the
+         * configuration and mode should mark it to be deleted and also doing a check in the system.
+         */
         if (
             $this->filesystem->isSymlinkedDirectory($packageFolder)
             || $this->filesystem->isJunction($packageFolder)

--- a/src/Composer/Command/CompileAssets.php
+++ b/src/Composer/Command/CompileAssets.php
@@ -25,6 +25,10 @@ final class CompileAssets extends BaseCommand
     use ModeOptionTrait;
     use ObtainComposerTrait;
 
+    public const OPTION_CLEAR_PACKAGE_MANAGER_CACHE = 'clear-cache-between-batches';
+    public const OPTION_FORCE_DELETE_NODE_MODULES = 'force-delete-node-modules';
+    public const OPTION_MAX_PARALLEL_PROCESSES = 'max-parallel-processes';
+
     /**
      * @return void
      */
@@ -58,7 +62,26 @@ final class CompileAssets extends BaseCommand
                 InputOption::VALUE_OPTIONAL,
                 'Ignore lock for either all or specific packages.',
                 Locker::IGNORE_ALL
-            );
+            )
+            ->addOption(
+                self::OPTION_CLEAR_PACKAGE_MANAGER_CACHE,
+                null,
+                InputOption::VALUE_NONE,
+                'Should the cache be cleared after processing a batch of groups?.'
+            )
+            ->addOption(
+                self::OPTION_FORCE_DELETE_NODE_MODULES,
+                null,
+                InputOption::VALUE_NONE,
+                'Should the process force delete node_modules folder?'
+            )
+            ->addOption(
+                self::OPTION_MAX_PARALLEL_PROCESSES,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The amount of parallel processes that can be ran in parallel'
+            )
+        ;
     }
 
     /**
@@ -68,7 +91,7 @@ final class CompileAssets extends BaseCommand
      *
      * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // phpcs:enable Inpsyde.CodeQuality.ReturnTypeDeclaration
 
@@ -79,7 +102,7 @@ final class CompileAssets extends BaseCommand
             $plugin = new Plugin();
             $plugin->activate($composer, $io);
 
-            $noDev = $input->hasOption('no-dev');
+            $isDev = !$input->hasOption('no-dev');
             $mode = $this->determineMode($input, $output);
 
             $ignoreLockRaw = $input->hasParameterOption('--ignore-lock', true)
@@ -87,11 +110,21 @@ final class CompileAssets extends BaseCommand
                 : null;
             $ignoreLock = ($ignoreLockRaw && is_string($ignoreLockRaw)) ? $ignoreLockRaw : '';
             ($ignoreLock === '*/*') and $ignoreLock = Locker::IGNORE_ALL;
+            $maxProcesses = $input->hasParameterOption('--' . self::OPTION_MAX_PARALLEL_PROCESSES)
+                ? (int) $input->getOption(self::OPTION_MAX_PARALLEL_PROCESSES)
+                : null;
+
+            $commandPassedArguments = new CompileAssetsPassedArguments(
+                $isDev,
+                $ignoreLock,
+                is_string($mode) ? $mode : null,
+                $input->hasParameterOption('--' . self::OPTION_CLEAR_PACKAGE_MANAGER_CACHE) ?? null,
+                $input->hasParameterOption('--' . self::OPTION_FORCE_DELETE_NODE_MODULES) ?? null,
+                $maxProcesses
+            );
 
             $plugin->runByCommand(
-                is_string($mode) ? $mode : null,
-                !$noDev,
-                $ignoreLock
+                $commandPassedArguments
             );
 
             return 0;

--- a/src/Composer/Command/CompileAssetsPassedArguments.php
+++ b/src/Composer/Command/CompileAssetsPassedArguments.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\AssetsCompiler\Composer\Command;
+
+class CompileAssetsPassedArguments
+{
+    /** @var bool  */
+    private $isDev;
+    /** @var null|string  */
+    private $mode;
+    /** @var string  */
+    private $ignoreLock;
+    /** @var null|true */
+    private $clearPackageManagerCache = null;
+    /** @var null|true */
+    private $forceDeleteNodeModules = null;
+    /** @var int|null  */
+    private $maxParallelProcesses = null;
+
+    public function __construct(
+        bool $isDev,
+        string $ignoreLock,
+        ?string $mode = null,
+        ?bool $clearPackageManagerCache = null,
+        ?bool $forceDeleteNodeModules = null,
+        ?int $maxParallelProcesses = null
+    ) {
+
+        $this->isDev = $isDev;
+        $this->mode = $mode;
+        $this->ignoreLock = $ignoreLock;
+        $this->clearPackageManagerCache = $clearPackageManagerCache;
+        $this->forceDeleteNodeModules = $forceDeleteNodeModules;
+        $this->maxParallelProcesses = $maxParallelProcesses;
+    }
+
+    public function isDev(): bool
+    {
+        return $this->isDev;
+    }
+
+    public function mode(): ?string
+    {
+        return $this->mode;
+    }
+
+    public function ignoreLock(): string
+    {
+        return $this->ignoreLock;
+    }
+
+    public function clearPackageManagerCache(): ?bool
+    {
+        return $this->clearPackageManagerCache;
+    }
+
+    public function forceDeleteNodeModules(): ?bool
+    {
+        return $this->forceDeleteNodeModules;
+    }
+
+    public function maxParallelProcesses(): ?int
+    {
+        return $this->maxParallelProcesses;
+    }
+}

--- a/src/Composer/Command/DeleteFolderCommand.php
+++ b/src/Composer/Command/DeleteFolderCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\AssetsCompiler\Composer\Command;
+
+use Composer\Command\BaseCommand;
+use Composer\Util\Filesystem;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Usage: composer filesystem-delete-folder --path="some"
+ */
+class DeleteFolderCommand extends BaseCommand
+{
+    public const COMMAND_NAME = 'filesystem-delete-folder';
+    public const OPTION_PATH = 'path';
+
+    /**
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName(static::COMMAND_NAME)
+            ->setDescription('Deletes a folder using PHP filesystem service')
+            ->addOption(
+                'path',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The path to delete folder'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $input->getOption(static::OPTION_PATH);
+        $filesystem = new Filesystem();
+        $output->writeln(sprintf('Deleting the directory in: %s', $path));
+
+        if (!is_dir($path)) {
+            return 2;
+        }
+
+        $filesystem->removeDirectory($path);
+
+        return 0;
+    }
+}

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -132,7 +132,13 @@ final class Plugin implements
     ): void {
 
         $this->mode = self::MODE_COMMAND;
-        $this->run(Factory::new($this->composer, $this->io, $env, $isDev, $ignoreLock));
+        $this->run(Factory::new(
+            $this->composer,
+            $this->io,
+            $env,
+            $isDev,
+            $ignoreLock
+        ));
     }
 
     /**

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -19,6 +19,7 @@ use Composer\Plugin\Capability\CommandProvider;
 use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
+use Inpsyde\AssetsCompiler\Composer\Command\CompileAssetsPassedArguments;
 use Inpsyde\AssetsCompiler\Util\Factory;
 use Inpsyde\AssetsCompiler\Util\Io;
 
@@ -84,7 +85,11 @@ final class Plugin implements
      */
     public function getCommands(): array
     {
-        return [new Command\CompileAssets(), new Command\AssetHash()];
+        return [
+            new Command\CompileAssets(),
+            new Command\AssetHash(),
+            new Command\DeleteFolderCommand(),
+        ];
     }
 
     /**
@@ -126,18 +131,14 @@ final class Plugin implements
      * @return void
      */
     public function runByCommand(
-        ?string $env,
-        bool $isDev,
-        string $ignoreLock = ''
+        CompileAssetsPassedArguments $arguments
     ): void {
 
         $this->mode = self::MODE_COMMAND;
         $this->run(Factory::new(
             $this->composer,
             $this->io,
-            $env,
-            $isDev,
-            $ignoreLock
+            $arguments
         ));
     }
 

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -108,7 +108,15 @@ final class Plugin implements
      */
     public function onAutorunBecauseInstall(Event $event): void
     {
-        $factory = Factory::new($this->composer, $this->io, null, $event->isDevMode());
+        $arguments = new CompileAssetsPassedArguments(
+            $event->isDevMode(),
+            ''
+        );
+        $factory = Factory::new(
+            $this->composer,
+            $this->io,
+            $arguments
+        );
         if ($factory->rootConfig()->autoRun()) {
             $this->mode or $this->mode = self::MODE_COMPOSER_INSTALL;
             $this->run($factory);

--- a/src/Process/ParallelManager.php
+++ b/src/Process/ParallelManager.php
@@ -114,23 +114,20 @@ class ParallelManager
 
     /**
      * @param Asset $asset
-     * @param string $command
-     * @param string ...$commands
+     * @param array{path: string, command: string} $commands
      * @return static
      */
     public function pushAssetToProcess(
         Asset $asset,
-        string $command,
-        string ...$commands
+        array $commands
     ): ParallelManager {
 
-        array_unshift($commands, $command);
-        $command = implode(' && ', $commands);
-
-        $process = $this->factory->create($command, (string)$asset->path());
-        $this->commands[$asset->name()] = $command;
-        $this->stack->enqueue([$process, $asset]);
-        $this->total++;
+        foreach ($commands as $command) {
+            $process = $this->factory->create($command['command'], $command['path']);
+            $this->stack->enqueue([$process, $asset]);
+            $this->total++;
+        }
+        $this->commands[$asset->name()] = json_encode($commands);
         $this->timeout += ($this->timeoutIncrement * count($commands));
 
         return $this;
@@ -257,8 +254,9 @@ class ParallelManager
             [$process, $asset] = $current;
 
             $name = $asset->name();
-            $command = $this->commands[$name] ?? '';
-            $io->writeComment("Starting process of '{$name}' using: `{$command}`...");
+            $command = $process->getCommandLine();
+
+            $io->writeComment("Starting '{$command}' for asset: `{$name}`...");
 
             $process->start($this->outputHandler);
             $running->enqueue([$process, $asset]);
@@ -310,17 +308,19 @@ class ParallelManager
                 continue;
             }
 
+            $command = $process->getCommandLine();
+
             if (!$process->isSuccessful()) {
                 $veryVerbose = $io->isVeryVerbose();
                 $prefix = $veryVerbose ? '' : "\n";
-                $io->writeError("{$prefix}Failed processing {$name}.");
+                $io->writeError("{$prefix}Failed processing of {$command} for {$name}.");
                 $veryVerbose and $this->writeProcessError($process, $io);
                 $erroneous->enqueue([$process, $asset]);
                 $stopAnyRunning or $stopAnyRunning = $stopOnFailure;
                 continue;
             }
 
-            $io->writeInfo("Processing of {$name} done successfully.");
+            $io->writeInfo("Processing of {$command} for {$name} done successfully.");
             $successful->enqueue([$process, $asset]);
         }
 

--- a/src/Process/ParallelProcessManager.php
+++ b/src/Process/ParallelProcessManager.php
@@ -67,7 +67,7 @@ class ParallelProcessManager
         }
 
         if ($onAllBatchesCompletedCallback !== null) {
-            $onBatchCompletedCallback();
+            $onAllBatchesCompletedCallback();
         }
     }
 

--- a/src/Process/ParallelProcessManager.php
+++ b/src/Process/ParallelProcessManager.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\AssetsCompiler\Process;
+
+use Symfony\Component\Process\Process;
+
+class ParallelProcessManager
+{
+    /**
+     * @var ProcessGroup[]
+     */
+    private $processGroups = [];
+
+    /**
+     * @var int
+     */
+    private $maxParallel;
+
+    /**
+     * @var Factory
+     */
+    private $processFactory;
+
+    public function __construct(
+        Factory $processFactory,
+        int $maxParallel = 4
+    ) {
+
+        $this->processFactory = $processFactory;
+        $this->maxParallel = $maxParallel;
+    }
+
+    public function addGroup(ProcessGroup $group): void
+    {
+        $this->processGroups[] = $group;
+    }
+
+    public function run(
+        ?callable $onBatchStartCallback = null,
+        ?callable $onBatchCompletedCallback = null,
+        ?callable $onAllBatchesCompletedCallback = null
+    ): void {
+
+        $allGroups = $this->processGroups;
+        $totalBatches = ceil(count($allGroups) / $this->maxParallel);
+        $batchNumber = 0;
+
+        // Process groups in batches
+        while (!empty($allGroups)) {
+            $batchNumber++;
+
+            // Take next batch of groups
+            $currentBatch = array_splice($allGroups, 0, $this->maxParallel);
+            $groupsCount = count($currentBatch);
+
+            if ($onBatchStartCallback) {
+                $onBatchStartCallback($currentBatch, $batchNumber, $totalBatches, $groupsCount);
+            }
+
+            $this->runBatch($currentBatch);
+
+            if (!empty($allGroups) && $onBatchCompletedCallback !== null) {
+                $onBatchCompletedCallback($currentBatch, $batchNumber, $totalBatches, $groupsCount);
+            }
+        }
+
+        if ($onAllBatchesCompletedCallback !== null) {
+            $onBatchCompletedCallback();
+        }
+    }
+
+    /**
+     * @param ProcessGroup[] $groups
+     * @param callable|null $onParentProcessStart
+     * @param callable|null $onProcessStart
+     * @return void
+     */
+    // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh,Inpsyde.CodeQuality.NestingLevel.MaxExceeded,Inpsyde.CodeQuality.FunctionLength.TooLong
+    private function runBatch(
+        array $groups,
+        ?callable $onProcessStart = null
+    ): void {
+
+        $activeGroups = $groups;
+
+        // Start all parent processes in this batch
+        foreach ($activeGroups as $group) {
+            $parentProcess = $group->getParent();
+            if ($group->getOnParentStartCallback()) {
+                ($group->getOnParentStartCallback())($parentProcess);
+            }
+            $parentProcess->start();
+        }
+
+        // Wait for all groups in batch to complete
+        while (!empty($activeGroups)) {
+            foreach ($activeGroups as $key => $group) {
+                $parent = $group->getParent();
+
+                // Check if parent is running
+                if (!$group->isParentCompleted()) {
+                    if (!$parent->isRunning()) {
+                        if (!$parent->isSuccessful()) {
+                            if ($group->getOnParentProcessErroredCallback()) {
+                                ($group->getOnParentProcessErroredCallback())($parent);
+                            }
+                        }
+                        $group->markParentCompleted();
+
+                        // Start first child if exists
+                        if ($group->hasMoreChildren()) {
+                            $currentChild = $group->getCurrentChild();
+                            if ($group->getOnChildStartCallback()) {
+                                ($group->getOnChildStartCallback())($currentChild);
+                            }
+                            $currentChild->start();
+                        }
+                    }
+                    // phpcs:ignore Inpsyde.CodeQuality.NoElse.ElseFound
+                } else {
+                    // Parent completed, handle children sequentially
+                    if ($group->hasMoreChildren()) {
+                        $currentChild = $group->getCurrentChild();
+
+                        if (!$currentChild->isRunning()) {
+                            if (!$currentChild->isSuccessful()) {
+                                throw new \RuntimeException(
+                                    "Child process failed: " . $currentChild->getErrorOutput()
+                                );
+                            }
+
+                            // Move to next child
+                            $group->moveToNextChild();
+
+                            // Start next child if exists
+                            if ($group->hasMoreChildren()) {
+                                $currentChild = $group->getCurrentChild();
+                                if ($group->getOnChildStartCallback()) {
+                                    ($group->getOnChildStartCallback())($currentChild);
+                                }
+                                $currentChild->start();
+                            }
+                        }
+                    }
+
+                    // Group is complete, remove it from active groups
+                    if ($group->isComplete()) {
+                        if ($group->getOnGroupCompletedCallback()) {
+                            ($group->getOnGroupCompletedCallback())();
+                        }
+                        unset($activeGroups[$key]);
+                    }
+                }
+            }
+
+            usleep(100000); // 100ms - prevent tight loop
+        }
+    }
+
+    public function createProcess(string $command, string $cwd): Process
+    {
+        return $this->processFactory->create($command, $cwd);
+    }
+}

--- a/src/Process/ParallelProcessManager.php
+++ b/src/Process/ParallelProcessManager.php
@@ -44,7 +44,7 @@ class ParallelProcessManager
     ): void {
 
         $allGroups = $this->processGroups;
-        $totalBatches = ceil(count($allGroups) / $this->maxParallel);
+        $totalBatches = (int) ceil(count($allGroups) / $this->maxParallel);
         $batchNumber = 0;
 
         // Process groups in batches

--- a/src/Process/ProcessGroup.php
+++ b/src/Process/ProcessGroup.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\AssetsCompiler\Process;
+
+use Symfony\Component\Process\Process;
+
+// phpcs:disable Inpsyde.CodeQuality.NoAccessors.NoGetter
+// phpcs:disable Inpsyde.CodeQuality.NoAccessors.NoSetter
+class ProcessGroup
+{
+    /**
+     * @var Process
+     */
+    private $parentProcess;
+    /**
+     * @var array
+     */
+    private $childProcesses = [];
+    /**
+     * @var bool
+     */
+    private $parentCompleted = false;
+    /**
+     * @var int
+     */
+    private $currentChildIndex = 0;
+
+    /**
+     * @var null|callable
+     */
+    private $onParentStartCallback = null;
+
+    /**
+     * @var null|callable
+     */
+    private $onChildStartCallback = null;
+
+    /**
+     * @var null|callable
+     */
+    private $onGroupCompletedCallback = null;
+
+    /**
+     * @var null|callable
+     */
+    private $onParentProcessErroredCallback = null;
+
+    /**
+     * @var null|callable
+     */
+    private $onChildProcessErroredCallback = null;
+
+    public function __construct(
+        Process $parentProcess,
+        ?callable $onParentStartCallback = null,
+        ?callable $onChildStartCallback = null,
+        ?callable $onGroupCompletedCallback = null,
+        ?callable $onParentProcessErroredCallback = null,
+        ?callable $onChildProcessErroredCallback = null
+    ) {
+
+        $this->parentProcess = $parentProcess;
+        $this->onParentStartCallback = $onParentStartCallback;
+        $this->onGroupCompletedCallback = $onGroupCompletedCallback;
+        $this->onChildStartCallback = $onChildStartCallback;
+        $this->onParentProcessErroredCallback = $onParentProcessErroredCallback;
+        $this->onChildProcessErroredCallback = $onChildProcessErroredCallback;
+    }
+
+    public function addChild(Process $process): self
+    {
+        $this->childProcesses[] = $process;
+        return $this;
+    }
+
+    public function getParent(): Process
+    {
+        return $this->parentProcess;
+    }
+
+    public function hasChildren(): bool
+    {
+        return !empty($this->childProcesses);
+    }
+
+    public function isParentCompleted(): bool
+    {
+        return $this->parentCompleted;
+    }
+
+    public function markParentCompleted(): void
+    {
+        $this->parentCompleted = true;
+    }
+
+    public function getCurrentChild(): ?Process
+    {
+        return $this->childProcesses[$this->currentChildIndex] ?? null;
+    }
+
+    public function moveToNextChild(): void
+    {
+        $this->currentChildIndex++;
+    }
+
+    public function hasMoreChildren(): bool
+    {
+        return $this->currentChildIndex < count($this->childProcesses);
+    }
+
+    public function isComplete(): bool
+    {
+        return $this->parentCompleted && !$this->hasMoreChildren();
+    }
+
+    public function getOnParentStartCallback(): ?callable
+    {
+        return $this->onParentStartCallback;
+    }
+
+    public function getOnGroupCompletedCallback(): ?callable
+    {
+        return $this->onGroupCompletedCallback;
+    }
+
+    public function getOnChildStartCallback(): ?callable
+    {
+        return $this->onChildStartCallback;
+    }
+
+    public function getOnParentProcessErroredCallback(): ?callable
+    {
+        return $this->onParentProcessErroredCallback;
+    }
+
+    public function getOnChildProcessErroredCallback(): ?callable
+    {
+        return $this->onChildProcessErroredCallback;
+    }
+}

--- a/src/Util/Factory.php
+++ b/src/Util/Factory.php
@@ -26,6 +26,7 @@ use Inpsyde\AssetsCompiler\Asset\Locker;
 use Inpsyde\AssetsCompiler\Asset\Asset;
 use Inpsyde\AssetsCompiler\Asset\Processor;
 use Inpsyde\AssetsCompiler\Asset\RootConfig;
+use Inpsyde\AssetsCompiler\Composer\Command\CompileAssetsPassedArguments;
 use Inpsyde\AssetsCompiler\PackageManager;
 use Inpsyde\AssetsCompiler\PreCompilation\ArchiveDownloaderAdapter;
 use Inpsyde\AssetsCompiler\PreCompilation\GithubActionArtifactAdapter;
@@ -33,6 +34,7 @@ use Inpsyde\AssetsCompiler\PreCompilation\GithubReleaseZipAdapter;
 use Inpsyde\AssetsCompiler\PreCompilation\Handler;
 use Inpsyde\AssetsCompiler\Process\Factory as ProcessFactory;
 use Inpsyde\AssetsCompiler\Process\ParallelManager;
+use Inpsyde\AssetsCompiler\Process\ParallelProcessManager;
 use Symfony\Component\Process\Process;
 
 final class Factory
@@ -63,6 +65,11 @@ final class Factory
     private $ignoreLock;
 
     /**
+     * @var CompileAssetsPassedArguments
+     */
+    private $passedArguments;
+
+    /**
      * @var array<string, object>
      */
     private $objects = [];
@@ -78,12 +85,10 @@ final class Factory
     public static function new(
         Composer $composer,
         IOInterface $io,
-        ?string $mode,
-        bool $isDev,
-        string $ignoreLock = ''
+        CompileAssetsPassedArguments $arguments
     ): Factory {
 
-        return new self($composer, $io, $mode, $isDev, $ignoreLock);
+        return new self($composer, $io, $arguments);
     }
 
     /**
@@ -96,16 +101,15 @@ final class Factory
     private function __construct(
         Composer $composer,
         IOInterface $io,
-        ?string $mode,
-        bool $isDev,
-        string $ignoreLock = ''
+        CompileAssetsPassedArguments $arguments
     ) {
 
         $this->composer = $composer;
         $this->io = $io;
-        $this->mode = $mode ?? Env::assetsCompilerMode();
-        $this->isDev = $isDev;
-        $this->ignoreLock = $ignoreLock;
+        $this->mode = $arguments->mode() ?? Env::assetsCompilerMode();
+        $this->isDev = $arguments->isDev();
+        $this->ignoreLock = $arguments->ignoreLock() ?? '';
+        $this->passedArguments = $arguments;
     }
 
     /**
@@ -576,16 +580,16 @@ final class Factory
     /**
      * @return ParallelManager
      */
-    public function processManager(): ParallelManager
+    public function processManager(): ParallelProcessManager
     {
         if (empty($this->objects[__FUNCTION__])) {
             $config = $this->rootConfig();
-            $this->objects[__FUNCTION__] = ParallelManager::new(
-                $this->processOutputHandler(),
+            $maxProcesses = $this->passedArguments->maxParallelProcesses() !== null
+                ? $this->passedArguments->maxParallelProcesses()
+                : $config->maxProcesses();
+            $this->objects[__FUNCTION__] = new ParallelProcessManager(
                 $this->processFactory(),
-                $config->maxProcesses(),
-                $config->processesPoll(),
-                $config->timeoutIncrement()
+                $maxProcesses
             );
         }
 
@@ -610,7 +614,8 @@ final class Factory
                 $this->locker(),
                 $this->preCompilationHandler(),
                 $this->processOutputHandler(),
-                $this->filesystem()
+                $this->filesystem(),
+                $this->passedArguments
             );
         }
 

--- a/tests/src/FunctionalTestCase.php
+++ b/tests/src/FunctionalTestCase.php
@@ -16,6 +16,7 @@ use Composer\Factory as ComposerFactory;
 use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Util\Filesystem;
+use Inpsyde\AssetsCompiler\Composer\Command\CompileAssetsPassedArguments;
 use Inpsyde\AssetsCompiler\Process\Factory as ProcessFactory;
 use Inpsyde\AssetsCompiler\Util\Factory;
 
@@ -113,7 +114,13 @@ abstract class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         $io = $this->factoryComposerIo($verbosity);
         $composer = $this->factoryComposer($io);
 
-        return Factory::new($composer, $io, $mode, $isDev, $ignoreLock);
+        $arguments = new CompileAssetsPassedArguments(
+            $isDev,
+            $ignoreLock,
+            $mode
+        );
+
+        return Factory::new($composer, $io, $arguments);
     }
 
     /**

--- a/tests/unit/Asset/ProcessorUnitTest.php
+++ b/tests/unit/Asset/ProcessorUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\AssetsCompiler\Tests\Asset;
+
+use Composer\Util\Filesystem;
+use Composer\Util\ProcessExecutor;
+use Inpsyde\AssetsCompiler\Asset\Config;
+use Inpsyde\AssetsCompiler\Asset\Locker;
+use Inpsyde\AssetsCompiler\Asset\Processor;
+use Inpsyde\AssetsCompiler\PackageManager\Finder;
+use Inpsyde\AssetsCompiler\PreCompilation\Handler;
+use Inpsyde\AssetsCompiler\Process\ParallelManager;
+use Inpsyde\AssetsCompiler\Tests\UnitTestCase;
+use Inpsyde\AssetsCompiler\Util\Io;
+use Mockery;
+
+class ProcessorUnitTest extends UnitTestCase
+{
+    public function testCreation(): void
+    {
+        $io = Mockery::mock(Io::class);
+        $config = Mockery::mock(Config::class);
+        $packageManagerFinder = Mockery::mock(Finder::class);
+        $processExecutor = Mockery::mock(ProcessExecutor::class);
+        $parallelManager = Mockery::mock(ParallelManager::class);
+        $locker = Mockery::mock(Locker::class);
+        $preCompiler = Mockery::mock(Handler::class);
+        $outputHanlder = static fn () => null;
+        $filesystem = Mockery::mock(Filesystem::class);
+
+        $processor = Processor::new(
+            $io,
+            $config,
+            $packageManagerFinder,
+            $processExecutor,
+            $parallelManager,
+            $locker,
+            $preCompiler,
+            $outputHanlder,
+            $filesystem,
+        );
+
+        $this->assertInstanceOf(Processor::class, $processor);
+    }
+}

--- a/tests/unit/Asset/ProcessorUnitTest.php
+++ b/tests/unit/Asset/ProcessorUnitTest.php
@@ -9,6 +9,7 @@ use Composer\Util\ProcessExecutor;
 use Inpsyde\AssetsCompiler\Asset\Config;
 use Inpsyde\AssetsCompiler\Asset\Locker;
 use Inpsyde\AssetsCompiler\Asset\Processor;
+use Inpsyde\AssetsCompiler\Composer\Command\CompileAssetsPassedArguments;
 use Inpsyde\AssetsCompiler\PackageManager\Finder;
 use Inpsyde\AssetsCompiler\PreCompilation\Handler;
 use Inpsyde\AssetsCompiler\Process\ParallelManager;
@@ -27,8 +28,11 @@ class ProcessorUnitTest extends UnitTestCase
         $parallelManager = Mockery::mock(ParallelManager::class);
         $locker = Mockery::mock(Locker::class);
         $preCompiler = Mockery::mock(Handler::class);
-        $outputHanlder = static fn () => null;
+        $outputHanlder = static function () {
+            return null;
+        };
         $filesystem = Mockery::mock(Filesystem::class);
+        $arguments = Mockery::mock(CompileAssetsPassedArguments::class);
 
         $processor = Processor::new(
             $io,
@@ -40,6 +44,7 @@ class ProcessorUnitTest extends UnitTestCase
             $preCompiler,
             $outputHanlder,
             $filesystem,
+            $arguments
         );
 
         $this->assertInstanceOf(Processor::class, $processor);


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

Solves #28 

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Refactor


## What is the current behavior? (You can also link to an open issue here)

Currently the parallel manager is not really running in parallel for the installs at least.
There is no possiblity to run callbacks in important points.
There is no possibility to run a callback after a set of parallel tasks are finished.


## What is the new behavior (if this is a feature change)?

Instead of running the processes in stages like: install, build, lock... we are now introducing the concept of ProcessGroups and Batches.
Each Assets will create a ProcessGroup, ProcessGroups can be worked in parallel and each Process group will have sequencial tasks.
We are also adding the possibity to pass callbacks When parent and children processes start.
We are reusing the existing max in parallel config to use it as max processes in parallel.
We are adding the possibility to pass a callback when each batch starts and finish.
We are adding the possibility to pass callbacks when a parent or child task errored.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
In the current state yes.

There is a `handleIsolatedCache` method that was not ported in this change yet
The `wipeNodemodules` is handled a bit different we are not checking for symlink, we will need to see how this behaves.

We are going to test it in one of our projects.


## Other information
