### PR TITLE
Add php 8.3 and 8.4 support

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -42,10 +42,10 @@ jobs:
         run: echo "USE_COVERAGE=yes" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php-ver }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
@@ -59,7 +59,7 @@ jobs:
             composer require --dev --no-update "composer/composer:${{ matrix.composer-ver }}"
 
       - name: Install dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # v2.3.1
 
       - name: Run unit tests
         run: |
@@ -67,7 +67,7 @@ jobs:
             ./vendor/bin/phpunit --testsuite=unit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-html=coverage-report') || '--no-coverage' }}
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ env.USE_COVERAGE == 'yes' }}
         with:
           name: coverage-report

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -29,22 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         php-ver: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
-        composer-ver: [ '^1', '~2.0.0', '~2.1.0', '~2.2.0', '~2.3.0', '~2.4.0', '~2.5.0' ]
-        exclude:
-          - php-ver: '8.1'
-            composer-ver: '^1'
-          - php-ver: '8.1'
-            composer-ver: '~2.0.0'
-          - php-ver: '8.2'
-            composer-ver: '^1'
-          - php-ver: '8.2'
-            composer-ver: '~2.0.0'
-          - php-ver: '8.2'
-            composer-ver: '~2.1.0'
-          - php-ver: '8.3'
-            composer-ver: '~2.1.0'
-          - php-ver: '8.4'
-            composer-ver: '~2.1.0'
+        composer-ver: [ '^1', '^2' ]
 
     steps:
       - name: Update "USE_COVERAGE" env var based on matrix

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -77,7 +77,7 @@ jobs:
             ./vendor/bin/phpunit --testsuite=unit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-html=coverage-report') || '--no-coverage' }}
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ env.USE_COVERAGE == 'yes' }}
         with:
           name: coverage-report

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -30,6 +30,11 @@ jobs:
       matrix:
         php-ver: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         composer-ver: [ '^1', '^2' ]
+        exclude:
+          # PHP 8.4 fails with composer/composer v1 due deprecated messages.
+          - php-ver: '8.4'
+            composer-ver: '^1'
+
 
     steps:
       - name: Update "USE_COVERAGE" env var based on matrix

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">= 7.2 <= 8.4",
+        "php": ">= 7.2",
         "ext-json": "*",
         "composer-plugin-api": "^1 || ^2"
     },


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Improvement

## What is the current behavior? (You can also link to an open issue here)

Currently, the `composer.json` file restricts to `php < 8.3`.

## What is the new behavior (if this is a feature change)?

The new behavior will remove that restriction on `require.php` and allow `php >= 7."` for version 3 of this package.

Additionally, we're going to remove the quite complex matrix of composer packages mapped to PHP versions. This was running into security advisor messages and failing test runs. The matrix was also outdated. The new behavior will be to test only against the latest v1 and the latest v2 of composer/composer.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Hopefully not. ;-)

## Other information
